### PR TITLE
Pi-types using nested functions. Checking for equality of expressions

### DIFF
--- a/dependent_types/__init__.py
+++ b/dependent_types/__init__.py
@@ -1,5 +1,6 @@
 import functools
 import inspect
+from types import SimpleNamespace
 
 
 class TypeDescriptor:
@@ -165,18 +166,27 @@ def test_dependant_types():
     @autofunc
     def List(T: Type) -> Type: ...
 
-    def cons(T: Type):
+    def lists(T: Type):
         @autofunc
         def cons(t: T, lst: List(T)) -> List(T): ...
 
-        return cons
+        nil = List(T)('nil')
 
-    def nil(T: Type):
-        return List(T)('nil')
+        @autofunc
+        def head(lst: List(T)) -> T: ...
+
+        @autofunc
+        def tail(lst: List(T)) -> List(T): ...
+
+        @autofunc
+        def append(lst1: List(T), lst2: List(T)) -> List(T): ...
+
+        return SimpleNamespace(**locals())
 
     A = Type('A')
     a = A('a')
-    print(cons(A)(a, cons(A)(a, nil(A))))
+    L = lists(A)
+    print(L.head(L.tail(L.cons(a, L.append(List(A)('lst'), L.nil)))))
 
 
 if __name__ == '__main__':

--- a/dependent_types/__init__.py
+++ b/dependent_types/__init__.py
@@ -29,28 +29,53 @@ class TypeMeta(BaseType, type):
 class Type(BaseType, metaclass=TypeMeta):
     universe = 0
 
-    def __init__(self, name=None, *, universe=None):
+    def __init__(self, name=None, *, expr=None, universe=None):
         assert bool(name) ^ bool(universe)
         self.name = name
         if name:
             self.type = Type
         self.universe = universe
+        self.expr = expr
 
-    def __call__(self, name):
-        result = Instance(self, name)
+    def __call__(self, name, expr=None):
+        if expr is None:
+            expr = FunctionApplication(self)
+        result = Instance(self, name, expr)
         result.type = self
         return result
 
     type = TypeDescriptor()
 
+    def __eq__(self, other):
+        return (
+                isinstance(other, BaseType)
+                and self.universe == other.universe
+                and self.expr == other.expr
+        )
+
 
 class Instance:
-    def __init__(self, typ, name):
+    def __init__(self, typ, name, expr):
         self.name = name
         self.type = typ
+        self.expr = expr
 
     def __repr__(self):
         return self.name
+
+    def __eq__(self, other):
+        return (
+                isinstance(other, Instance)
+                and self.expr == other.expr
+        )
+
+
+class FunctionApplication:
+    def __init__(self, *args):
+        self.args = args
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.args == other.args
 
 
 def autofunc(f):
@@ -60,7 +85,8 @@ def autofunc(f):
     def func(*args):
         typ = signature.return_annotation
         name = f'{f.__name__}({", ".join(arg.name for arg in args)})'
-        return typ(name)
+        expr = FunctionApplication(f.__code__, *args)
+        return typ(name, expr=expr)
 
     return check_types(func)
 
@@ -121,6 +147,36 @@ def main():
     c = composed(A('a'))
     print(c)
     assert c.type is C
+
+    test_dependant_types()
+
+
+def test_dependant_types():
+    """
+    constant List   : Type → Type
+
+    constant cons   : Π T : Type, T → List T → List T
+    constant nil    : Π T : Type, List T
+    constant head   : Π T : Type, List T → T
+    constant tail   : Π T : Type, List T → List T
+    constant append : Π T : Type, List T → List T → List T
+    """
+
+    @autofunc
+    def List(T: Type) -> Type: ...
+
+    def cons(T: Type):
+        @autofunc
+        def cons(t: T, lst: List(T)) -> List(T): ...
+
+        return cons
+
+    def nil(T: Type):
+        return List(T)('nil')
+
+    A = Type('A')
+    a = A('a')
+    print(cons(A)(a, cons(A)(a, nil(A))))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Part of #1. It seems that Pi types don't need a new construct, they can just be treated like nested functions. In fact lean returns the same for the following:

```lean
#check λ (α β γ : Type) (g : β → γ) (f : α → β) (x : α), g (f x)

#check λ (α β γ : Type), (λ (g : β → γ) (f : α → β) (x : α), g (f x))
```