### PR TITLE
Arrow types

### DIFF
--- a/dependent_types/__init__.py
+++ b/dependent_types/__init__.py
@@ -39,8 +39,6 @@ class Type(BaseType, metaclass=TypeMeta):
         self.value = value
 
     def __call__(self, name, value=None):
-        if value is None:
-            value = FunctionApplication(self)
         result = Instance(self, name, value)
         result.type = self
         return result
@@ -107,16 +105,6 @@ class ArrowInstance(Instance):
 
     def raise_on_result_type_error(self, result):
         assert result.type == self.type.signature.return_annotation
-
-
-
-
-class FunctionApplication:
-    def __init__(self, *args):
-        self.args = args
-
-    def __eq__(self, other):
-        return type(self) == type(other) and self.args == other.args
 
 
 def arrow(f):
@@ -195,7 +183,9 @@ def test_dependent_types():
         @arrow
         def cons(t: T, lst: List(T)) -> List(T): ...
 
-        nil = List(T)('nil')
+        @arrow
+        def nil() -> List(T): 
+            return List(T)('nil')
 
         @arrow
         def head(lst: List(T)) -> T: ...
@@ -213,7 +203,11 @@ def test_dependent_types():
 
     a = A('a')    
     L = lists(A)
-    print(L.head(L.tail(L.cons(a, L.append(List(A)('lst'), L.nil)))))
+
+    print(L.nil.type)
+    assert L.nil().type == List(A)
+
+    print(L.head(L.tail(L.cons(a, L.append(List(A)('lst'), L.nil())))))
 
 
 if __name__ == '__main__':

--- a/dependent_types/__init__.py
+++ b/dependent_types/__init__.py
@@ -149,10 +149,10 @@ def main():
     print(c)
     assert c.type is C
 
-    test_dependant_types()
+    test_dependent_types()
 
 
-def test_dependant_types():
+def test_dependent_types():
     """
     constant List   : Type → Type
 


### PR DESCRIPTION
Concerning #2.

Introduced an Arrow subclass of Type and ArrowInstance which basically replaces the FunctionApplication class

Mathematicians will not understand the meaning of the autofunc decorator, which is renamed to arrow which is a bit more familiar.

The ArrowType is constructed by a passing a function signature object. This makes it easy to construct the correct ArrowType when decorating an annotated function. The 'arrow' decorator now returns an instance of ArrowType. 

Some minor adjustments made to the List Pi implementation, to play well with the arrow decorator.
